### PR TITLE
auto rebuild daily as required

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,11 @@
 name: release
 
-
-on: [pull_request]
+on:
+  schedule:
+    - cron: '15 3 * * *'  # run daily at 03:15
 
 jobs:
-  gh-pages:
+  rebuild:
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,43 @@
+name: release
+
+
+on: [pull_request]
+
+jobs:
+  gh-pages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: update
+        run: |
+          git submodule status --recursive > before
+          git submodule update --recursive --init
+          git submodule status --recursive > after
+          if diff before after; then
+            echo 'No update required' >&2
+            exit 1
+          fi
+      - name: configure ruby
+        uses: actions/setup-ruby@v1.1.1
+        with:
+          ruby-version: '2.7'
+      - name: install
+        run: |
+          gem install plist
+      - name: build
+        run: |
+          ruby build.rb
+          sed -i "s/Last updated.*:/Last updated: $(date +%Y-%m-%d)/" README.md
+      - name: configure git
+        run: |
+          git config --local 'user.email' 'action@github.com'
+          git config --local 'user.name' 'GitHub Action'
+      - name: commit
+        run: |
+          new_version="$(git -C cylc-textmate-grammar/ rev-parse HEAD)"
+          git commit -a -m "update: ${new_version}"
+      - name: push
+        run: |
+          repo="https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}"
+          git push "${repo}" HEAD:master

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Cylc TextMate Grammar
 
+Last updated: 2020
+
 A TextMate bundle for working with [Cylc](http://www.cylc.org) workflow
 configuration files.
 


### PR DESCRIPTION
Setup a cron job to auto-rebuild this repo if anything changes in cylc-textmate-grammar.

Note: we looked into using a push system rather than polling for changes but this proved difficult for security, and setup reaons. Polling seems to be a valid solution as it only takes ~4 seconds to determine whether an update is required.

You can see this in action on my fork, take a look at the last action run on this PR: https://github.com/oliver-sanders/Cylc.tmbundle/pull/2

Note that it failed because I pushed my master one commit ahead to prevent it from succeeding (requires force push).